### PR TITLE
hubot-asana requires @assignments to be lowercase

### DIFF
--- a/asana.coffee
+++ b/asana.coffee
@@ -57,6 +57,7 @@ module.exports = (robot) ->
     if userAcct
       userAcct = userAcct.replace /^\s+|\s+$/g, ""
       userAcct = userAcct.replace "@", ""
+      userAcct = userAcct.toLowerCase()
       getRequest msg, "/workspaces/#{workspace}/users", (err, res, body) ->
         response = JSON.parse body
         assignedUser = ""


### PR DESCRIPTION
Because the code does a `toLowerCase()` on the names coming from API data (https://github.com/idpro/hubot-asana/blob/master/asana.coffee#L64), Hubot command necessarily has to take a lowercase form or the equality doesn't return true (https://github.com/idpro/hubot-asana/blob/master/asana.coffee#L65)

If you `toLowerCase()` input data as well, that should not longer be necessary.

Cross-pulled to https://github.com/github/hubot-scripts/pull/1155
